### PR TITLE
Fix: Force redeploy to restore oss.lat

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,3 +2,4 @@ title: OpenSource LATAM
 copyright: 'Copyright © 2022-{year} OpenSource LATAM Community. All Rights Reserved.'
 baseURL: https://oss.lat/
 theme: hugo-theme-bootstrap
+ 


### PR DESCRIPTION
Triggers a new build to include the corrected CNAME location.